### PR TITLE
[AIPLATFORM-1850] 검색, 자동완성 API query_string 형식으로 변경

### DIFF
--- a/API_SERVICE/meta_service/main.py
+++ b/API_SERVICE/meta_service/main.py
@@ -4,8 +4,8 @@ from fastapi import FastAPI
 from meta_service.common.config import logger
 from meta_service.common.config import settings
 from meta_service.database.conn import db
-from meta_service.routes.v1 import els_data_search, els_update
-from meta_service.routes.v2 import autocomplete
+from meta_service.routes.v1 import els_update
+from meta_service.routes.v2 import autocomplete, els_data_search
 
 
 def create_app():

--- a/API_SERVICE/meta_service/main.py
+++ b/API_SERVICE/meta_service/main.py
@@ -4,7 +4,8 @@ from fastapi import FastAPI
 from meta_service.common.config import logger
 from meta_service.common.config import settings
 from meta_service.database.conn import db
-from meta_service.routes.v1 import autocomplete, els_data_search, els_update
+from meta_service.routes.v1 import els_data_search, els_update
+from meta_service.routes.v2 import autocomplete
 
 
 def create_app():

--- a/API_SERVICE/meta_service/main.py
+++ b/API_SERVICE/meta_service/main.py
@@ -4,8 +4,7 @@ from fastapi import FastAPI
 from meta_service.common.config import logger
 from meta_service.common.config import settings
 from meta_service.database.conn import db
-from meta_service.routes.v1 import els_update
-from meta_service.routes.v2 import autocomplete, els_data_search
+from meta_service.routes.v2 import autocomplete, els_data_search, els_update
 
 
 def create_app():

--- a/API_SERVICE/meta_service/routes/v1/autocomplete.py
+++ b/API_SERVICE/meta_service/routes/v1/autocomplete.py
@@ -32,11 +32,16 @@ logger = logging.getLogger()
 def autocomplete(input: CoreOption, index: str, size: int):
     #input.field는 list 형식으로 받아야함, keywords는 string으로 받아야함
     try:
+        
         docmanager = default_search_set(dev_server, index, size)
         if len(input.field) > 1:
             # multi field 일 때
             logger.info("multi_match")
             prefix_query = base_query(1, [input])
+            
+            for query_dict in prefix_query:
+                query_dict["multi_match"].pop("operator",None)
+            
             body = make_format("query","bool",{"must": prefix_query})
             docmanager.set_body(body)
             prefix_dict = search_filter(docmanager.find(input.field))

--- a/API_SERVICE/meta_service/routes/v2/autocomplete.py
+++ b/API_SERVICE/meta_service/routes/v2/autocomplete.py
@@ -1,0 +1,54 @@
+import logging
+
+from fastapi import APIRouter
+
+from meta_service.database.conn import db
+from libs.database.connector import Connector
+
+from meta_service.ELKSearch.config import dev_server
+from meta_service.ELKSearch.model import CoreOption
+from meta_service.ELKSearch.Utils.base import make_format
+from meta_service.ELKSearch.Utils.document_utils import search_filter
+
+from meta_service.common.search import default_search_set, base_query
+
+
+from pydantic import BaseModel
+
+
+class Prefix(BaseModel):
+    index: str
+    size: int
+    fields: list
+    query: str
+
+
+router = APIRouter()
+
+logger = logging.getLogger()
+
+
+@router.post("/autocomplete", response_model=dict)
+def autocomplete(input: Prefix):
+    try:
+        keyword = input.query
+        docmanager = default_search_set(dev_server, input.index, input.size)
+        input.query = f"(*{input.query}*)"
+        del input.index
+        del input.size
+        
+        body = make_format("query","query_string",input.dict())
+        
+        docmanager.set_body(body)
+        prefix_dict = search_filter(docmanager.find(input.fields))
+
+        if not len(prefix_dict):
+            return {"result": 1,"data": []}
+
+        prefix_data = [ word for data in prefix_dict for word in data.values() if keyword in word]
+        result = {"result": 1,"data": prefix_data}
+    except Exception as e:
+        result = {"result": 0, "errorMessage": str(e)}
+        logger.error(e, exc_info=True)
+
+    return result

--- a/API_SERVICE/meta_service/routes/v2/autocomplete.py
+++ b/API_SERVICE/meta_service/routes/v2/autocomplete.py
@@ -38,7 +38,6 @@ def autocomplete(input: Prefix):
         del input.size
         
         body = make_format("query","query_string",input.dict())
-        
         docmanager.set_body(body)
         prefix_dict = search_filter(docmanager.find(input.fields))
 
@@ -46,7 +45,8 @@ def autocomplete(input: Prefix):
             return {"result": 1,"data": []}
 
         prefix_data = [ word for data in prefix_dict for word in data.values() if keyword in word]
-        result = {"result": 1,"data": prefix_data}
+        # 데이터셋에서 해당 되는 데이터가 여러개 있을 수 있어 prefix_data에 size를 줌
+        result = {"result": 1,"data": prefix_data[:docmanager.size]}
     except Exception as e:
         result = {"result": 0, "errorMessage": str(e)}
         logger.error(e, exc_info=True)

--- a/API_SERVICE/meta_service/routes/v2/autocomplete.py
+++ b/API_SERVICE/meta_service/routes/v2/autocomplete.py
@@ -30,6 +30,22 @@ logger = logging.getLogger()
 
 @router.post("/autocomplete", response_model=dict)
 def autocomplete(input: Prefix):
+    """
+    :param input:
+    {
+        "index": "index_name",
+        "size": 5,
+        "fields": [
+            "col1", "col2"
+        ],
+        "query": "search keyword"
+    }
+    :return:
+    {
+        "result": 1,
+        "data": ["data1","data2"..."data5"]
+    }
+    """
     try:
         keyword = input.query
         docmanager = default_search_set(dev_server, input.index, input.size)

--- a/API_SERVICE/meta_service/routes/v2/els_data_search.py
+++ b/API_SERVICE/meta_service/routes/v2/els_data_search.py
@@ -20,9 +20,31 @@ logger = logging.getLogger()
 @router.post("/search")
 def search(input: InputModel, session: Connector = Depends(db.get_db)):
     """
-
     :param input:
+    {
+        "index": "index_name",
+        "from": 0,    # page
+        "size": 10,   # result size
+        "resultField": ["col1", "col2"],
+        "sortOption": [{"col": "desc"}],
+        "searchOption": [
+            {
+                "field": ["conm"],
+                "operator": "OR",
+                "keywords": ["기업명"]
+            }
+        ],
+        "filterOption": []
+    }
     :return:
+    {
+        "result": 1,
+        "data": {
+            "header": {"column_name": "col1", "kor_column_name": "컬럼명1"},
+            "count": "10",  # total count
+            "body": [{data set 1}, {data set 2} ...]
+        }
+    }
     """
     try:
         len_search = len(input.searchOption)

--- a/API_SERVICE/meta_service/routes/v2/els_data_search.py
+++ b/API_SERVICE/meta_service/routes/v2/els_data_search.py
@@ -1,0 +1,63 @@
+import logging
+
+from fastapi import APIRouter, Depends
+
+from meta_service.database.conn import db
+from libs.database.connector import Connector
+
+from meta_service.ELKSearch.config import dev_server
+from meta_service.ELKSearch.model import InputModel
+from meta_service.ELKSearch.Utils.base import make_format
+from meta_service.ELKSearch.Utils.document_utils import search_filter
+
+from meta_service.common.search import default_search_set, base_query
+
+
+router = APIRouter()
+
+logger = logging.getLogger()
+
+@router.post("/search")
+def search(input: InputModel, session: Connector = Depends(db.get_db)):
+    """
+
+    :param input:
+    :return:
+    """
+    try:
+        len_search = len(input.searchOption)
+        len_filter = len(input.filterOption)
+
+        # from_ 0 부터 시작해야함, web에서는 1부터 넘어오기 때문에 1을 빼준다
+        docmanager = default_search_set(dev_server, input.index, input.size, input.from_ - 1)
+
+        # query에 조건이 없으면 match all 실행 
+        if not any([len_filter,len_search]):
+            body = make_format("query","match_all",dict())
+        else:
+            search_format = "(*{0}*)"
+            search_query = []
+            for query in input.searchOption:
+                keywords = [search_format.format(keyword) for keyword in query.keywords]
+                if len(keywords) > 1:
+                    keywords = f" {query.operator} ".join(keywords)    
+                else:
+                    keywords = keywords[0]
+                search_query.append({"query_string": {"query": keywords ,"fields": query.field}})
+
+            # search_query = base_query(len_search, input.searchOption)
+            filter_query = base_query(len_filter, input.filterOption)
+            body = make_format("query","bool", {"must": search_query,"filter": filter_query})
+            logger.info(body)
+
+        docmanager.set_body(body)
+        data = {
+            "header": session.get_column_info(input.index.upper()),
+            "count": docmanager.count(body),
+            "body": search_filter(docmanager.find(input.resultField))
+        }
+        result = {"result": 1, "data": data}
+    except Exception as e:
+        result = {"result": 0, "errorMessage": str(e)}
+        logger.error(e, exc_info=True)
+    return result

--- a/API_SERVICE/meta_service/routes/v2/els_data_search.py
+++ b/API_SERVICE/meta_service/routes/v2/els_data_search.py
@@ -42,7 +42,7 @@ def search(input: InputModel, session: Connector = Depends(db.get_db)):
         "data": {
             "header": {"column_name": "col1", "kor_column_name": "컬럼명1"},
             "count": "10",  # total count
-            "body": [{data set 1}, {data set 2} ...]
+            "body": [{data set 1}, {data set 2} ... {data set 10}]
         }
     }
     """

--- a/API_SERVICE/meta_service/routes/v2/els_update.py
+++ b/API_SERVICE/meta_service/routes/v2/els_update.py
@@ -1,0 +1,48 @@
+import logging
+import decimal
+
+from fastapi import Depends, APIRouter
+
+from meta_service.database.conn import db
+from libs.database.connector import Connector
+
+from meta_service.ELKSearch.config import dev_server
+from meta_service.common.search import default_search_set
+
+
+router = APIRouter()
+
+logger = logging.getLogger()
+
+
+@router.post("/els-update", response_model=dict)
+def els_update(index: str, session: Connector = Depends(db.get_db)):
+
+    # data_query = "SELECT {0} FROM {1};"
+    data_query = {"table_nm": index}
+    
+    try:
+        cur = session.conn.cursor()
+        column_dict = session.get_column_info(index)
+        columns = [col["column_name"] for col in column_dict]
+        logger.info(columns)
+        rows = session.query(**data_query).all()[0]
+
+        docmanager = default_search_set(dev_server, index)
+
+        insert_dataset = []
+        for row in rows:
+            insert_body = dict()
+            for i in range(0,len(columns)):
+                if type(row[columns[i]]) ==decimal.Decimal:
+                    insert_body[columns[i]] = int(row[columns[i]])
+                else:
+                    insert_body[columns[i]] = row[columns[i]]
+            docmanager.set_body(insert_body)
+            logger.info(docmanager.insert(insert_body["idx"]))
+        result = {"result":1,"data": "test"}
+
+    except Exception as e:
+        result = {"result": 0, "errorMessage": str(e)}
+        logger.error(e, exc_info=True)
+    return result


### PR DESCRIPTION
#### Description
- 중간글자로 검색 하면 검색되지 않는 이슈
    - tokenizer설정을 default로 주었기 때문에 띄어쓰기 기준으로 단어가 나눠짐
    - db의 like검색과 유사하게 동작하기 위해  must > match 검색을 query_string형식으로 변경
- DB 사용법을 router에서 사용하는 common select와 같은 형식으로 동작하게 변경
- 검색, 자동완성 입출력 주석 추가